### PR TITLE
fix: Use media_new_path instead of media_new

### DIFF
--- a/technical_director/technical_director.py
+++ b/technical_director/technical_director.py
@@ -112,7 +112,7 @@ class TechnicalDirector:
             video = self.video_queue.pop(0)
         except IndexError:
             video = Video.default_video()
-        media = self.vlc_controller.vlc_instance.media_new(video.file_path)
+        media = self.vlc_controller.vlc_instance.media_new_path(video.file_path)
         # If start_at_second is specified, we don't bother with chapters,
         # commercials, etc. Just queue the video from the time specified.
         # This usually occurs when there is not enough time in the timeslot


### PR DESCRIPTION
Use `media_new_path` instead of `media_new`.

According to [the python vlc binding docs](https://www.olivieraubert.net/vlc/python-ctypes/doc/vlc.Instance-class.html#media_new), using `media_new` will result in vlc treating paths with a `:` as URLs.

> If mrl contains a colon (:) preceded by more than 1 letter, it will be treated as a URL. Else, it will be considered as a local path. If you need more control, directly use media_new_location/media_new_path methods

We only use file paths, never URLs, so `media_new_path` is appropriate here.