### PR TITLE
Recover when video hangs.

### DIFF
--- a/technical_director/technical_director.py
+++ b/technical_director/technical_director.py
@@ -6,7 +6,7 @@ import socket
 import time
 from decimal import Decimal
 
-from vlc import EventType, State
+from vlc import EventType
 from vlc_controller import VLCController
 
 from commercial_utils import get_commercial_break
@@ -101,10 +101,10 @@ class TechnicalDirector:
 
     def react_to_vlc_media_player_end_reached_event(self, event):
         # Hey there. The reason this just sets a flag and doesn't just start
-        # the next video itself is because event handlers are not re-entrant
-        # Attempting to call methods on the player object while reacting to
-        # a player event will cause the player to hang. Instead this just
-        # sets a semaphore that is read during the main loop.
+        # the next video itself is because attempting to call methods on the
+        # player object while reacting to a player event causes the player to
+        # hang. Instead this just sets a semaphore that is read during the main
+        # loop.
         self.should_move_to_next_video = True
 
     def play_next_video(self):
@@ -120,13 +120,12 @@ class TechnicalDirector:
         # Well, it can happen if you turn your channel on in the middle of a
         # timeslot. In this case it would be like the content had been playing,
         # it finishes exactly on time.
-        options = []
         if video.start_at_second:
-            options.append(f':start-time={round(Decimal(video.start_at_second), 3)}')
+            media.add_option(f':start-time={round(Decimal(video.start_at_second), 3)}')
         if video.end_at_second:
-            options.append(f":stop-time={round(Decimal(video.end_at_second), 3)}")
+            media.add_option(f":stop-time={round(Decimal(video.end_at_second), 3)}")
 
-        self.vlc_controller.set_mrl(media.get_mrl(), options)
+        self.vlc_controller.set_media(media)
 
         self.vlc_controller.play()
         self.current_video_started = datetime.datetime.now()
@@ -301,9 +300,6 @@ class TechnicalDirector:
 
 
     def queue_fill_advance_and_sleep_loop(self):
-
-        beats_since_reaching_end = 0
-
         while True:
             remaining_queue_duration = self.remaining_queue_duration_in_seconds()
             if remaining_queue_duration < (30 * 60):
@@ -315,6 +311,8 @@ class TechnicalDirector:
                 remaining_seconds = int(remaining_queue_duration)
                 remaining_milliseconds = int((remaining_queue_duration - remaining_seconds) * 1000)
 
+
+
                 # TODO: Ensure this is into the next timeslot. Don't feed the
                 # queue with what's already playing.
                 self.feed_queue(queue_feed_time + datetime.timedelta(seconds=remaining_seconds, milliseconds=remaining_milliseconds))
@@ -323,16 +321,6 @@ class TechnicalDirector:
             if self.should_move_to_next_video:
                 self.should_move_to_next_video = False
                 self.play_next_video()
-
-            # I haven't figured out why, but sometimes the player will get stuck in the "Playing"
-            # state, even though the video has played completely. When we recognize we've been in
-            # this situation for two trips through the main loop, we'll manually intervene and move
-            # to the next video.
-            if self.vlc_controller.player.get_state() == State.Playing and self.vlc_controller.player.get_position() > 1:
-                beats_since_reaching_end += 1
-                if beats_since_reaching_end > 2:
-                    self.should_move_to_next_video = True
-                    beats_since_reaching_end = 0
 
             time.sleep(0.5)
 

--- a/technical_director/technical_director.py
+++ b/technical_director/technical_director.py
@@ -6,7 +6,7 @@ import socket
 import time
 from decimal import Decimal
 
-from vlc import EventType
+from vlc import EventType, State
 from vlc_controller import VLCController
 
 from commercial_utils import get_commercial_break
@@ -101,10 +101,10 @@ class TechnicalDirector:
 
     def react_to_vlc_media_player_end_reached_event(self, event):
         # Hey there. The reason this just sets a flag and doesn't just start
-        # the next video itself is because attempting to call methods on the
-        # player object while reacting to a player event causes the player to
-        # hang. Instead this just sets a semaphore that is read during the main
-        # loop.
+        # the next video itself is because event handlers are not re-entrant
+        # Attempting to call methods on the player object while reacting to
+        # a player event will cause the player to hang. Instead this just
+        # sets a semaphore that is read during the main loop.
         self.should_move_to_next_video = True
 
     def play_next_video(self):
@@ -120,12 +120,13 @@ class TechnicalDirector:
         # Well, it can happen if you turn your channel on in the middle of a
         # timeslot. In this case it would be like the content had been playing,
         # it finishes exactly on time.
+        options = []
         if video.start_at_second:
-            media.add_option(f':start-time={round(Decimal(video.start_at_second), 3)}')
+            options.append(f':start-time={round(Decimal(video.start_at_second), 3)}')
         if video.end_at_second:
-            media.add_option(f":stop-time={round(Decimal(video.end_at_second), 3)}")
+            options.append(f":stop-time={round(Decimal(video.end_at_second), 3)}")
 
-        self.vlc_controller.set_media(media)
+        self.vlc_controller.set_mrl(media.get_mrl(), options)
 
         self.vlc_controller.play()
         self.current_video_started = datetime.datetime.now()
@@ -300,6 +301,9 @@ class TechnicalDirector:
 
 
     def queue_fill_advance_and_sleep_loop(self):
+
+        beats_since_reaching_end = 0
+
         while True:
             remaining_queue_duration = self.remaining_queue_duration_in_seconds()
             if remaining_queue_duration < (30 * 60):
@@ -311,8 +315,6 @@ class TechnicalDirector:
                 remaining_seconds = int(remaining_queue_duration)
                 remaining_milliseconds = int((remaining_queue_duration - remaining_seconds) * 1000)
 
-
-
                 # TODO: Ensure this is into the next timeslot. Don't feed the
                 # queue with what's already playing.
                 self.feed_queue(queue_feed_time + datetime.timedelta(seconds=remaining_seconds, milliseconds=remaining_milliseconds))
@@ -321,6 +323,16 @@ class TechnicalDirector:
             if self.should_move_to_next_video:
                 self.should_move_to_next_video = False
                 self.play_next_video()
+
+            # I haven't figured out why, but sometimes the player will get stuck in the "Playing"
+            # state, even though the video has played completely. When we recognize we've been in
+            # this situation for two trips through the main loop, we'll manually intervene and move
+            # to the next video.
+            if self.vlc_controller.player.get_state() == State.Playing and self.vlc_controller.player.get_position() > 1:
+                beats_since_reaching_end += 1
+                if beats_since_reaching_end > 2:
+                    self.should_move_to_next_video = True
+                    beats_since_reaching_end = 0
 
             time.sleep(0.5)
 

--- a/technical_director/technical_director.py
+++ b/technical_director/technical_director.py
@@ -99,7 +99,7 @@ class TechnicalDirector:
                 block_duration_in_seconds=scheduling_block['block_duration_in_minutes'] * 60)
         self.print_queue()
 
-    def react_to_vlc_media_player_end_reached_event(self, event):
+    def react_to_vlc_stopping(self, event):
         # Hey there. The reason this just sets a flag and doesn't just start
         # the next video itself is because attempting to call methods on the
         # player object while reacting to a player event causes the player to
@@ -319,8 +319,13 @@ class TechnicalDirector:
 
             # Advance the queue if it's ready.
             if self.should_move_to_next_video:
-                self.should_move_to_next_video = False
-                self.play_next_video()
+                # Make sure we are responding to the same event twice (or two
+                # different events spawned from the same action) by verifying
+                # it has been at least a second since the video started.
+                elapsed = (datetime.datetime.now() - self.current_video_started).total_seconds()
+                if elapsed > 1.0:
+                    self.should_move_to_next_video = False
+                    self.play_next_video()
 
             time.sleep(0.5)
 
@@ -328,9 +333,11 @@ class TechnicalDirector:
 td = TechnicalDirector()
 
 # Attach an event listener to the VLC player so that we can play the next video
-# as soon as VLC reports that the in progress one has finished.
+# as soon as VLC reports that the in progress one has stopped for any reason
 events = td.vlc_controller.player.event_manager()
-events.event_attach(EventType.MediaPlayerEndReached, td.react_to_vlc_media_player_end_reached_event)
+events.event_attach(EventType.MediaPlayerEndReached, td.react_to_vlc_stopping)
+events.event_attach(EventType.MediaPlayerEncounteredError, td.react_to_vlc_stopping)
+events.event_attach(EventType.MediaPlayerStopped, td.react_to_vlc_stopping)
 
 # Hit play
 td.play_next_video()

--- a/technical_director/vlc_controller.py
+++ b/technical_director/vlc_controller.py
@@ -15,5 +15,5 @@ class VLCController:
     def play(self):
         self.player.play()
 
-    def set_mrl(self, mrl, options = []):
-        self.player.set_mrl(mrl, *options)
+    def set_media(self, media):
+        self.player.set_media(media)

--- a/technical_director/vlc_controller.py
+++ b/technical_director/vlc_controller.py
@@ -15,5 +15,5 @@ class VLCController:
     def play(self):
         self.player.play()
 
-    def set_media(self, media):
-        self.player.set_media(media)
+    def set_mrl(self, mrl, options = []):
+        self.player.set_mrl(mrl, *options)


### PR DESCRIPTION
Try to recognize a scenario where the video has reached its end but the player doesn't stop, and manually intervene.

Sometimes, and seemingly randomly, a video file will reach its end (position >= 1.0), but the video player stays in the "Playing" state, which means the `MediaPlayerEndReached` event never fires, which means we never advance to the next video.

This change checks if we exist in this state for two beats of the main loop (1s) and manually intervenes if so.